### PR TITLE
Adds dispatch and getState forwarding to thunk functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ export const getProfile = createThunk(
 );
 ```
 
+If you need to access your store, or dispatch extra actions from your thunk, you can use `dispatch` and `getState` as parameters your thunk.
+
+Example:
+
+Dispatching some custom analytics event that requires store data:
+```js
+// src/actions/userActions.js
+import { createThunk } from '@rootstrap/redux-tools'
+
+export const getProfile = createThunk(
+  'GET_PROFILE',
+  async (userId, dispatch, getState) => {
+    const { analytics: { analyticsToken } } = getState();
+    const profile = await userService.getProfile(profileId);
+    dispatch(analytics.logProfile(analyticsToken, profile));
+    return profile;
+  },
+);
+```
+
 You can then dispatch this `getProfile` action, and the middleware will automatically dispatch actions with types `GET_PROFILE_SUCCESS` or `GET_PROFILE_ERROR` for you.
 
 `createThunk` receives the action names prefix as the first argument and the async thunk as the second.
@@ -88,8 +108,8 @@ To reset the status of an action you can dispatch the `reset` action returned by
 
 ### Step 1: install the package
 
-`npm i @rootstrap/redux-tools`  
-or  
+`npm i @rootstrap/redux-tools`
+or
 `yarn add @rootstrap/redux-tools`
 
 ### Step 2: configure the reducer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rootstrap/redux-tools",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Redux tools we use in both react bases",
   "main": "lib/index.js",
   "files": [

--- a/src/createThunk.js
+++ b/src/createThunk.js
@@ -5,7 +5,7 @@ import createAction from './createAction'
  * Creates different actions creators
  *
  * @param {string} actionName - Action name, will be used as a prefix for the action creators.
- * @param {function} thunk - This is your async thunk
+ * @param {function} thunk - This is your async thunk, receives all forwarded params and `dispatch` and `getState` as params
  *
  * @returns {ActionCreator} Action that can be dispatched to start the async thunk, can also be
  * deconstructed to get request, error, and success action creators (can be used as keys in reducer)
@@ -27,7 +27,7 @@ export default (actionName, thunk) => {
   const action = (...params) => ({
     success,
     error,
-    thunk: () => thunk(...params),
+    thunk: (dispatch, getState) => thunk(...params, dispatch, getState),
     type: request.toString(),
   })
 

--- a/src/thunkMiddleware.js
+++ b/src/thunkMiddleware.js
@@ -1,10 +1,10 @@
-export default ({ dispatch }) => next => async action => {
+export default ({ dispatch, getState }) => next => async action => {
   next(action)
 
   const { thunk, success, error } = action
   if (typeof thunk === 'function') {
     try {
-      const response = await thunk()
+      const response = await thunk(dispatch, getState)
       dispatch(success(response))
     } catch (err) {
       dispatch(error(err))


### PR DESCRIPTION
- Now you can use `dispatch` and `getState` on your thunk functions.
- There's a new example added to the readme