### PR TITLE
Add ability to add error parsing function to middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,5 +126,7 @@ import { thunkMiddleware } from '@rootstrap/redux-tools'
 
 import rootReducer from 'src/reducers/index'
 
-const store = createStore(rootReducer, applyMiddleware(thunkMiddleware))
+const store = createStore(rootReducer, applyMiddleware(thunkMiddleware()))
 ```
+
+`thunkMiddleware` accepts a function as an optional parameter. This function will be used to transform the error before dispatching it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rootstrap/redux-tools",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Redux tools we use in both react bases",
   "main": "src/index.js",
   "files": [
@@ -44,7 +44,7 @@
     "redux-mock-store": "^1.5.3"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
+    "react": "^16.8.0",
     "redux": "^4.0.4",
     "react-redux": "^7.1.1"
   }

--- a/src/thunkMiddleware.js
+++ b/src/thunkMiddleware.js
@@ -1,4 +1,7 @@
-export default ({ dispatch, getState }) => next => async action => {
+export default parseError => ({
+  dispatch,
+  getState,
+}) => next => async action => {
   next(action)
 
   const { thunk, success, error } = action
@@ -7,7 +10,8 @@ export default ({ dispatch, getState }) => next => async action => {
       const response = await thunk(dispatch, getState)
       dispatch(success(response))
     } catch (err) {
-      dispatch(error(err))
+      if (parseError) dispatch(error(parseError(err)))
+      else dispatch(error(err))
     }
   }
 }

--- a/tests/thunkMiddleware.spec.js
+++ b/tests/thunkMiddleware.spec.js
@@ -3,7 +3,8 @@ import configureStore from 'redux-mock-store'
 import thunkMiddleware from '../src/thunkMiddleware'
 import createThunk from '../src/createThunk'
 
-const mockStore = configureStore([thunkMiddleware])
+const parseError = error => error.toString()
+let mockStore = configureStore([thunkMiddleware()])
 
 describe('actionThunk Middleware', () => {
   let store
@@ -47,6 +48,20 @@ describe('actionThunk Middleware', () => {
       await store.dispatch(mockSuccessAction())
       const actions = store.getActions()
       expect(actions).toContainEqual(mockSuccessAction.success(success))
+    })
+  })
+
+  describe('when adding a parseError function', () => {
+    const mockStoreWithErrorParsing = configureStore([
+      thunkMiddleware(parseError),
+    ])({})
+
+    describe('when dispatching the action that fails', () => {
+      it('should dispatch the error action with the parsed error', async () => {
+        await mockStoreWithErrorParsing.dispatch(mockErrorAction())
+        const actions = mockStoreWithErrorParsing.getActions()
+        expect(actions).toContainEqual(mockErrorAction.error(parseError(error)))
+      })
     })
   })
 })


### PR DESCRIPTION
Adds an optional parameter to `thunkMiddleware` so that it can parse errors for us.