### PR TITLE
Add rollup for commonjs support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 package-lock.json
 lib
+
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,14 +1,18 @@
 {
   "name": "@rootstrap/redux-tools",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Redux tools we use in both react bases",
-  "main": "src/index.js",
+  "main": "lib/index.js",
+  "module": "src/index.js",
   "files": [
     "src",
+    "lib",
     "README.md"
   ],
   "scripts": {
-    "test": "jest tests"
+    "test": "jest tests",
+    "build": "rollup -c",
+    "prepare": "rollup -c"
   },
   "repository": {
     "type": "git",
@@ -29,8 +33,9 @@
     "immer": "^5.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.8.6",
-    "@babel/preset-env": "^7.8.6",
+    "rollup": "^1.29.0",
+    "@babel/core": "^7.9.0",
+    "@babel/preset-env": "^7.9.0",
     "babel-jest": "^25.1.0",
     "eslint": "^6.6.0",
     "eslint-config-prettier": "^6.5.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,9 @@
+import pkg from './package.json';
+
+export default {
+  input: 'src/index.js',
+  external: ['immer', 'react-redux'],
+  output: [
+    { file: pkg.main, format: 'cjs' },
+  ]
+}


### PR DESCRIPTION
Adds rollup in order to support `commonjs` (node) and therefore SSR.